### PR TITLE
Using proper method to send command message

### DIFF
--- a/src/ui/sensorpodstatus.cpp
+++ b/src/ui/sensorpodstatus.cpp
@@ -84,8 +84,10 @@ void SensorpodStatus::PowerCycleSensorpodCmd()
 
 	if (reply == QMessageBox::Yes) {
 		//Send the message via the currently active UAS
-		ASLUAV *tempUAS = (ASLUAV*) UASManager::instance()->getActiveUAS();;
-        if (tempUAS) tempUAS->SendCommandLongTarget(MAV_CMD_PAYLOAD_CONTROL, (uint8_t) 50, 1.0f);
+		ASLUAV *tempUAS = (ASLUAV*) UASManager::instance()->getActiveUAS();
+	        if (tempUAS) {
+			tempUAS->SendCommandLong(MAV_CMD_PAYLOAD_CONTROL, 1.0f);
+		}
 	}
 
 }


### PR DESCRIPTION
Using `SendCommandLong(..)` instead of `SendCommandLongTarget(..)` to send `MAV_CMD_PAYLOAD_CONTROL` message.
Now `CompId` is not defined explicitly anymore.

(I really don't know why I did not use `SendCommandLong(..)` in the first place :-/)
