### PR TITLE
Fix/energybudget

### DIFF
--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -415,10 +415,10 @@ void ParameterManager::refreshAllParameters(uint8_t componentId)
                                              componentId);
     if (_vehicle->priorityLink()->getLinkConfiguration()->type() == 0 && !(_vehicle->satcomActive())) {
         _vehicle->sendMessageOnLink(_vehicle->priorityLink(), msg);
-    }
 
-    QString what = (componentId == MAV_COMP_ID_ALL) ? "MAV_COMP_ID_ALL" : QString::number(componentId);
-    qCDebug(ParameterManagerLog) << _logVehiclePrefix() << "Request to refresh all parameters for component ID:" << what;
+        QString what = (componentId == MAV_COMP_ID_ALL) ? "MAV_COMP_ID_ALL" : QString::number(componentId);
+        qCDebug(ParameterManagerLog) << _logVehiclePrefix() << "Request to refresh all parameters for component ID:" << what;
+    }
 }
 
 /// Translates FactSystem::defaultComponentId to real component id if needed

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -60,6 +60,7 @@ public:
     Q_INVOKABLE void saveToFile(const QString& filename);
     Q_INVOKABLE void removeAll(void);                       ///< Removes all from controller only, synce required to remove from vehicle
     Q_INVOKABLE void removeAllFromVehicle(void);            ///< Removes all from vehicle and controller
+    Q_INVOKABLE void setHomePosition(void);
 
     MissionController*      missionController(void)     { return &_missionController; }
     GeoFenceController*     geoFenceController(void)    { return &_geoFenceController; }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -677,6 +677,17 @@ QGCView {
         }
     }
 
+    Component {
+        id: setHomePositionDialog
+        QGCViewMessage {
+            message: qsTr("Do you want to set the current position as home position?")
+            function accept() {
+                masterController.setHomePosition()
+                hideDialog()
+            }
+        }
+    }
+
     //- ToolStrip DropPanel Components
 
     Component {
@@ -791,6 +802,17 @@ QGCView {
                         dropPanel.hide()
                         _qgcView.showDialog(removeAllPromptDialog, qsTr("Remove all"), _qgcView.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
                     }
+                }
+
+                QGCButton {
+                    text:               qsTr("Set Home Position")
+                    Layout.fillWidth:   true
+                    enabled:            !masterController.offline && !masterController.syncInProgress
+                    onClicked:  {
+                        dropPanel.hide()
+                        _qgcView.showDialog(setHomePositionDialog, qsTr("Set Home Position"), _qgcView.showDialogDefaultWidth, StandardButton.Yes | StandardButton.No)
+                    }
+
                 }
             }
         }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -133,10 +133,7 @@ void ParameterEditorController::loadFromFile(const QString& filename)
 
 void ParameterEditorController::refresh(void)
 {
-
-    if (_vehicle->priorityLink()->getLinkConfiguration()->type() == 0 && !(_vehicle->satcomActive())) {
-        _vehicle->parameterManager()->refreshAllParameters();
-    }
+    _vehicle->parameterManager()->refreshAllParameters();
 }
 
 void ParameterEditorController::resetAllToDefaults(void)

--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -4,41 +4,41 @@
     "shortDescription": "Automatically open a connection over UDP",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a UDP communication link.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 },
 {
     "name":             "AutoconnectPixhawk",
     "shortDescription": "Automatically connect to a Pixhawk board",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a Pixhawk board which is connected via USB.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 },
 {
     "name":             "Autoconnect3DRRadio",
     "shortDescription": "Automatically connect to a SiK Radio",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a SiK Radio communication link.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 },
 {
     "name":             "AutoconnectPX4Flow",
     "shortDescription": "Automatically connect to a P4 Flow",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a PX4 Flow board which is connected via USB.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 },
 {
     "name":             "AutoconnectRTKGPS",
     "shortDescription": "Automatically connect to an RTK GPS",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to an RTK GPS which is connected via USB.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 },
 {
     "name":             "AutoconnectLibrePilot",
     "shortDescription": "Automatically connect to a LibrePilot",
     "longDescription":  "If this option is enabled GroundControl will automatically connect to a LibrePilot board which is connected via USB.",
     "type":             "bool",
-    "defaultValue":     true
+    "defaultValue":     false
 }
 ]

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -40,7 +40,7 @@ MultiVehicleManager::MultiVehicleManager(QGCApplication* app, QGCToolbox* toolbo
 {
     QSettings settings;
 
-    _gcsHeartbeatEnabled = settings.value(_gcsHeartbeatEnabledKey, true).toBool();
+    _gcsHeartbeatEnabled = settings.value(_gcsHeartbeatEnabledKey, false).toBool();
 
     _gcsHeartbeatTimer.setInterval(_gcsHeartbeatRateMSecs);
     _gcsHeartbeatTimer.setSingleShot(false);

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -36,7 +36,7 @@ MultiVehicleManager::MultiVehicleManager(QGCApplication* app, QGCToolbox* toolbo
     , _firmwarePluginManager(NULL)
     , _joystickManager(NULL)
     , _mavlinkProtocol(NULL)
-    , _gcsHeartbeatEnabled(true)
+    , _gcsHeartbeatEnabled(false)
 {
     QSettings settings;
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1175,19 +1175,19 @@ void Vehicle::_handleAslHighLatency(mavlink_message_t &message)
     emit WPnumChanged(data.wp_num);
 
     // mppts
-    emit MPPTDataChanged(data.v_avg_mppt0 / 10.0f, (data.p_avg_bat + data.p_out) / (3.0f * data.v_avg_mppt0), 0, 0, data.v_avg_mppt1 / 10.0f, (data.p_avg_bat + data.p_out) / (3.0f * data.v_avg_mppt1), 0, 0, data.v_avg_mppt2 / 10.0f, (data.p_avg_bat + data.p_out) / (3.0f * data.v_avg_mppt2), 0, 0);
+    emit MPPTDataChangedHL(data.v_avg_mppt0, data.v_avg_mppt1, data.v_avg_mppt2);
 
     // batmon states
     // TDOO: adapt data.state_batmon (16 -> 8 bit)
-    emit BatMonDataChanged(LEFTBATMONCOMPID, data.v_avg_bat0 * 100.0f, 0, 0, 0, 0, 0, 0, data.state_batmon0, 0, 0, 0, 0, 0, 0);
-    emit BatMonDataChanged(CENTERBATMONCOMPID, data.v_avg_bat1 * 100.0f, 0, 0, 0, 0, 0, 0, data.state_batmon1, 0, 0, 0, 0, 0, 0);
-    emit BatMonDataChanged(RIGHTBATMONCOMPID, data.v_avg_bat2 * 100.0f, 0, 0, 0, 0, 0, 0, data.state_batmon2, 0, 0, 0, 0, 0, 0);
+    emit BatMonDataChangedHL(LEFTBATMONCOMPID, data.v_avg_bat0, data.p_avg_bat, data.state_batmon0);
+    emit BatMonDataChangedHL(CENTERBATMONCOMPID, data.v_avg_bat1, data.p_avg_bat, data.state_batmon1);
+    emit BatMonDataChangedHL(RIGHTBATMONCOMPID, data.v_avg_bat2, data.p_avg_bat, data.state_batmon2);
 
     // powerboard status
     emit SensPowerBoardChanged(data.status_pwrbrd);
 
     // p_out
-    emit SensPowerChanged(data.p_out * 2, 1, 0, 0);
+    emit SensPowerChangedHL(data.p_out);
 
 }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1168,6 +1168,7 @@ void Vehicle::_handleAslHighLatency(mavlink_message_t &message)
     _groundSpeedFact.setRawValue(data.groundspeed / 10.0f);
 
     // temperature_air
+    _temperatureFactGroup.temperature1()->setRawValue(data.temperature_air);
 
     // failsafe
 
@@ -1178,7 +1179,6 @@ void Vehicle::_handleAslHighLatency(mavlink_message_t &message)
     emit MPPTDataChangedHL(data.v_avg_mppt0, data.v_avg_mppt1, data.v_avg_mppt2);
 
     // batmon states
-    // TDOO: adapt data.state_batmon (16 -> 8 bit)
     emit BatMonDataChangedHL(LEFTBATMONCOMPID, data.v_avg_bat0, data.p_avg_bat, data.state_batmon0);
     emit BatMonDataChangedHL(CENTERBATMONCOMPID, data.v_avg_bat1, data.p_avg_bat, data.state_batmon1);
     emit BatMonDataChangedHL(RIGHTBATMONCOMPID, data.v_avg_bat2, data.p_avg_bat, data.state_batmon2);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -741,9 +741,12 @@ signals:
     void AirspeedChanged(float airspeed);
     void AslctrlDataChanged(float uElev, float uAil, float uRud, float uThrot, float roll, float pitch, float yaw, float roll_ref, float pitch_ref, float h);
     void MPPTDataChanged(float volt1, float amp1, uint16_t pwm1, uint8_t status1, float volt2, float amp2, uint16_t pwm2, uint8_t status2, float volt3, float amp3, uint16_t pwm3, uint8_t status3);
+    void MPPTDataChangedHL(uint8_t volt1, uint8_t volt2, uint8_t volt3);
     void BatMonDataChanged(uint8_t compid, uint16_t volt, int16_t current, uint8_t soc, float temp, uint16_t batStatus, uint32_t safetystatus, uint32_t operationstatus, uint8_t batmonStatusByte, uint16_t cellvolt1, uint16_t cellvolt2, uint16_t cellvolt3, uint16_t cellvolt4, uint16_t cellvolt5, uint16_t cellvolt6);
+    void BatMonDataChangedHL(uint8_t compid, uint8_t volt, int8_t p_avg, uint8_t batmonStatusByte);
     void SensorpodStatusChanged(uint8_t rate1, uint8_t rate2, uint8_t rate3, uint8_t rate4, uint8_t numRecordTopics, uint8_t cpuTemp, uint16_t freeSpace);
     void SensPowerChanged(float vspb_volt, float cspb_amp, float cs1_amp, float cs2_amp);
+    void SensPowerChangedHL(uint8_t p_out);
     void SensPowerBoardChanged(uint8_t pwr_brd_status);
     void speedChanged(Vehicle* vehicle, double groundspeed, double airspeed);
     void thrustChanged(Vehicle* vehicle, double thrust);

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -52,7 +52,7 @@ const char* MAVLinkProtocol::_logFileExtension = "mavlink";             ///< Ext
  */
 MAVLinkProtocol::MAVLinkProtocol(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
-    , m_enable_version_check(true)
+    , m_enable_version_check(false)
     , versionMismatchIgnore(false)
     , systemId(255)
 #ifndef __mobile__

--- a/src/ui/EnergyBudget.cc
+++ b/src/ui/EnergyBudget.cc
@@ -136,7 +136,7 @@ m_MPPTUpdateReset(new QTimer(this))
 	ui->ResetMPPTEdit->setValidator(new QIntValidator(this));
     if (qgcApp()->toolbox()->multiVehicleManager()->activeVehicle())
     {
-        setActiveUAS();
+        setActiveUAS(qgcApp()->toolbox()->multiVehicleManager()->activeVehicle());
     }
     m_MPPTUpdateReset->start();
 }
@@ -575,7 +575,7 @@ void EnergyBudget::updateGraphicsImage(void)
 //    ui->overviewGraphicsView->fitInView(m_scene->sceneRect(), Qt::AspectRatioMode::KeepAspectRatio);
 //}
 
-void EnergyBudget::setActiveUAS(void)
+void EnergyBudget::setActiveUAS(Vehicle* vehicle)
 {
     //disconnect any previous uas
     disconnect(this, SLOT(updatePower(float, float, float, float)));
@@ -588,7 +588,7 @@ void EnergyBudget::setActiveUAS(void)
     disconnect(this, SLOT(onSensPowerBoardChanged(uint8_t)));
 
     //connect the uas if asluas
-    Vehicle* tempUAS = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    Vehicle* tempUAS = vehicle;
 
     connect(tempUAS, SIGNAL(SensPowerChanged(float, float, float, float)), this, SLOT(updatePower(float, float, float, float)));
     connect(tempUAS, SIGNAL(SensPowerChangedHL(uint8_t)), this, SLOT(updatePowerHL(uint8_t)));

--- a/src/ui/EnergyBudget.cc
+++ b/src/ui/EnergyBudget.cc
@@ -68,8 +68,9 @@ m_MPPTUpdateReset(new QTimer(this))
     ui->overviewGraphicsView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     ui->overviewGraphicsView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	this->buildGraphicsImage();
-	ui->overviewGraphicsView->setScene(m_scene);
-    ui->overviewGraphicsView->fitInView(m_scene->sceneRect(), Qt::KeepAspectRatio);
+    ui->overviewGraphicsView->setScene(m_scene);
+    ui->overviewGraphicsView->fitInView(QRectF(0,0,150,150), Qt::AspectRatioMode::KeepAspectRatio);
+    //ui->overviewGraphicsView->fitInView(m_scene->sceneRect(), Qt::AspectRatioMode::KeepAspectRatio);
     connect(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::vehicleAdded, this, &EnergyBudget::setActiveUAS);
 
     // set LED size
@@ -128,7 +129,7 @@ m_MPPTUpdateReset(new QTimer(this))
     ui->bat3PFLed->setState(false);
 
 	connect(ui->ResetMPPTButton, SIGNAL(clicked()), this, SLOT(ResetMPPTCmd()));
-	connect(qgcApp(), SIGNAL(styleChanged(bool)), this, SLOT(styleChanged(bool)));
+    //connect(qgcApp(), SIGNAL(styleChanged(bool)), this, SLOT(styleChanged(bool)));
 	m_MPPTUpdateReset->setInterval(MPPTRESETTIMEMS);
 	m_MPPTUpdateReset->setSingleShot(false);
 	connect(m_MPPTUpdateReset, SIGNAL(timeout()), this, SLOT(MPPTTimerTimeout()));
@@ -152,8 +153,8 @@ EnergyBudget::~EnergyBudget()
 
 void EnergyBudget::buildGraphicsImage()
 {
-	m_scene->setSceneRect(0.0, 0.0, 1000.0, 1000.0);
-	qreal penWidth(40);
+    m_scene->setSceneRect(0.0, 0.0, 1000.0, 1000.0);
+    qreal penWidth(40);
 	// scale and place images
 
     QRectF tempRectF=m_propPixmap->boundingRect();
@@ -200,9 +201,10 @@ void EnergyBudget::buildGraphicsImage()
 	m_BckpBatText->setVisible(false);
 
     // set the right textcolor
-    this->styleChanged(qgcApp()->toolbox()->settingsManager()->appSettings()->indoorPalette()->rawValue().toBool());
+    styleChanged(qgcApp()->toolbox()->settingsManager()->appSettings()->indoorPalette()->rawValue().toBool());
+
 	// Recalc scene bounding rect
-	m_scene->setSceneRect(QRectF(0.0, 0.0, 0.0, 0.0));
+    m_scene->setSceneRect(QRectF(0.0, 0.0, 0.0, 0.0));
 }
 
 qreal EnergyBudget::adjustImageScale(const QRectF &viewSize, QRectF &img)
@@ -220,6 +222,18 @@ void EnergyBudget::updatePower(float volt, float currpb, float curr_1, float cur
 	ui->powerVValue->setText(QString("%1").arg(volt));
 
 	updateGraphicsImage();
+}
+
+void EnergyBudget::updatePowerHL(uint8_t p_out)
+{
+    m_propUsePower = p_out * 2;
+    m_SystemUsePowerText->setPlainText(QString("%1W @Thr %2%").arg(m_propUsePower, 0, 'f', 1).arg(m_thrust*100.0,0,'f',0));
+    ui->powerA1Value->setText(QString("N/A"));
+    ui->powerA2Value->setText(QString("N/A"));
+    ui->powerAValue->setText(QString("N/A"));
+    ui->powerVValue->setText(QString("N/A"));
+
+    updateGraphicsImage();
 }
 
 void EnergyBudget::onSensPowerBoardChanged(uint8_t pwr_brd_status)
@@ -245,12 +259,6 @@ void EnergyBudget::onSensPowerBoardChanged(uint8_t pwr_brd_status)
 
 void EnergyBudget::updateBatMon(uint8_t compid, uint16_t volt, int16_t current, uint8_t soc, float temp, uint16_t batStatus, uint32_t batSafety, uint32_t batOperation, uint8_t batmonStatusByte, uint16_t cellvolt1, uint16_t cellvolt2, uint16_t cellvolt3, uint16_t cellvolt4, uint16_t cellvolt5, uint16_t cellvolt6)
 {
-	Q_UNUSED(cellvolt1);
-	Q_UNUSED(cellvolt2);
-	Q_UNUSED(cellvolt3);
-	Q_UNUSED(cellvolt4);
-	Q_UNUSED(cellvolt5);
-	Q_UNUSED(cellvolt6);
 	switch (compid)
 	{
     case LEFTBATMONCOMPID:
@@ -357,6 +365,116 @@ void EnergyBudget::updateBatMon(uint8_t compid, uint16_t volt, int16_t current, 
 	updateGraphicsImage();
 }
 
+void EnergyBudget::updateBatMonHL(uint8_t compid, uint8_t volt, int8_t p_avg, uint8_t batmonStatusByte)
+{
+    switch (compid)
+    {
+    case LEFTBATMONCOMPID:
+            ui->bat1VLabel->setText(QString("%1").arg(volt / 10.0));
+            ui->bat1VLabel_2->setText(QString("%1").arg(volt / 10.0));
+            ui->bat1ALabel->setText(QString("N/A"));
+            ui->bat1PowerLabel->setText(QString("%1").arg(p_avg * 4 / 3.0));
+            ui->bat1CurrentLabel_2->setText(QString("N/A"));
+            ui->bat1StatLabel->setText(QString("N/A"));
+            ui->bat1SafetyLabel->setText(QString("N/A"));
+            ui->bat1OperLabel->setText(QString("N/A"));
+            ui->bat1TempLabel->setText(QString("N/A"));
+            ui->bat1SoCBar->setValue(QString("N/A").toInt());
+            ui->bat1Cell1Label->setText(QString("N/A"));
+            ui->bat1Cell2Label->setText(QString("N/A"));
+            ui->bat1Cell3Label->setText(QString("N/A"));
+            ui->bat1Cell4Label->setText(QString("N/A"));
+            ui->bat1Cell5Label->setText(QString("N/A"));
+            ui->bat1Cell6Label->setText(QString("N/A"));
+            ui->bat1FCLed->setState((bool)(0x1 & (batmonStatusByte >> 0)));
+            ui->bat1FDLed->setState((bool)(0x1 & (batmonStatusByte >> 1)));
+            ui->bat1COVLed->setState((bool)(0x1 & (batmonStatusByte >> 2)));
+            ui->bat1CUVLed->setState((bool)(0x1 & (batmonStatusByte >> 3)));
+            ui->bat1OTCLed->setState((bool)(0x1 & (batmonStatusByte >> 4)));
+            ui->bat1DSGLed->setState((bool)(0x1 & (batmonStatusByte >> 5)));
+            ui->bat1CHGLed->setState((bool)(0x1 & (batmonStatusByte >> 6)));
+            ui->bat1PFLed->setFlashing((bool)(0x1 & (batmonStatusByte >> 7)));
+            break;
+
+    case CENTERBATMONCOMPID:
+            ui->bat2VLabel->setText(QString("%1").arg(volt / 10.0));
+            ui->bat2VLabel_2->setText(QString("%1").arg(volt / 10.0));
+            ui->bat2ALabel->setText(QString("N/A"));
+            ui->bat2PowerLabel->setText(QString("%1").arg(p_avg * 4 / 3.0));
+            ui->bat2CurrentLabel_2->setText(QString("N/A"));
+            ui->bat2StatLabel->setText(QString("N/A"));
+            ui->bat2SafetyLabel->setText(QString("N/A"));
+            ui->bat2OperLabel->setText(QString("N/A"));
+            ui->bat2TempLabel->setText(QString("N/A"));
+            ui->bat2SoCBar->setValue(QString("N/A").toInt());
+            ui->bat2Cell1Label->setText(QString("N/A"));
+            ui->bat2Cell2Label->setText(QString("N/A"));
+            ui->bat2Cell3Label->setText(QString("N/A"));
+            ui->bat2Cell4Label->setText(QString("N/A"));
+            ui->bat2Cell5Label->setText(QString("N/A"));
+            ui->bat2Cell6Label->setText(QString("N/A"));
+            ui->bat2FCLed->setState((bool)(0x1 & (batmonStatusByte >> 0)));
+            ui->bat2FDLed->setState((bool)(0x1 & (batmonStatusByte >> 1)));
+            ui->bat2COVLed->setState((bool)(0x1 & (batmonStatusByte >> 2)));
+            ui->bat2CUVLed->setState((bool)(0x1 & (batmonStatusByte >> 3)));
+            ui->bat2OTCLed->setState((bool)(0x1 & (batmonStatusByte >> 4)));
+            ui->bat2DSGLed->setState((bool)(0x1 & (batmonStatusByte >> 5)));
+            ui->bat2CHGLed->setState((bool)(0x1 & (batmonStatusByte >> 6)));
+            ui->bat2PFLed->setFlashing((bool)(0x1 & (batmonStatusByte >> 7)));
+            break;
+
+    case RIGHTBATMONCOMPID:
+            ui->bat3VLabel->setText(QString("%1").arg(volt / 10.0));
+            ui->bat3VLabel_2->setText(QString("%1").arg(volt / 10.0));
+            ui->bat3ALabel->setText(QString("N/A"));
+            ui->bat3PowerLabel->setText(QString("%1").arg(p_avg * 4 / 3.0));
+            ui->bat3CurrentLabel_2->setText(QString("N/A"));
+            ui->bat3StatLabel->setText(QString("N/A"));
+            ui->bat3SafetyLabel->setText(QString("N/A"));
+            ui->bat3OperLabel->setText(QString("N/A"));
+            ui->bat3TempLabel->setText(QString("N/A"));
+            ui->bat3SoCBar->setValue(QString("N/A").toInt());
+            ui->bat3Cell1Label->setText(QString("N/A"));
+            ui->bat3Cell2Label->setText(QString("N/A"));
+            ui->bat3Cell3Label->setText(QString("N/A"));
+            ui->bat3Cell4Label->setText(QString("N/A"));
+            ui->bat3Cell5Label->setText(QString("N/A"));
+            ui->bat3Cell6Label->setText(QString("N/A"));
+            ui->bat3FCLed->setState((bool)(0x1 & (batmonStatusByte >> 0)));
+            ui->bat3FDLed->setState((bool)(0x1 & (batmonStatusByte >> 1)));
+            ui->bat3COVLed->setState((bool)(0x1 & (batmonStatusByte >> 2)));
+            ui->bat3CUVLed->setState((bool)(0x1 & (batmonStatusByte >> 3)));
+            ui->bat3OTCLed->setState((bool)(0x1 & (batmonStatusByte >> 4)));
+            ui->bat3DSGLed->setState((bool)(0x1 & (batmonStatusByte >> 5)));
+            ui->bat3CHGLed->setState((bool)(0x1 & (batmonStatusByte >> 6)));
+            ui->bat3PFLed->setFlashing((bool)(0x1 & (batmonStatusByte >> 7)));
+            break;
+    }
+
+    float power((ui->bat1PowerLabel->text().toDouble() + ui->bat2PowerLabel->text().toDouble() + ui->bat3PowerLabel->text().toDouble()));
+    if (m_batHystHigh->check(power))
+    {
+        m_batCharging = batChargeStatus::CHRG;
+        m_chargePower = power;
+        m_batUsePower = 0;
+    }
+    else if(!(m_batHystLow->check(power)))
+    {
+        m_batCharging = batChargeStatus::DSCHRG;
+        m_chargePower = 0;
+        m_batUsePower = -power;
+    }
+    else
+    {
+        m_batCharging = batChargeStatus::LVL;
+        m_chargePower = 0;
+        m_batUsePower = 0;
+    }
+    updateGraphicsImage();
+}
+
+
+
 void EnergyBudget::updateMPPT(float volt1, float amp1, uint16_t pwm1, uint8_t status1, float volt2, float amp2, uint16_t pwm2, uint8_t status2, float volt3, float amp3, uint16_t pwm3, uint8_t status3)
 {
 	m_MPPTUpdateReset->stop();
@@ -382,6 +500,33 @@ void EnergyBudget::updateMPPT(float volt1, float amp1, uint16_t pwm1, uint8_t st
 	m_cellPower = (volt1*amp1 + volt2*amp2 + volt3*amp3);
 	updateGraphicsImage();
 	m_MPPTUpdateReset->start(MPPTRESETTIMEMS);
+}
+
+void EnergyBudget::updateMPPTHL(uint8_t volt1, uint8_t volt2, uint8_t volt3)
+{
+    m_MPPTUpdateReset->stop();
+    ui->mppt1VLabel->setText(QString("%1").arg(volt1 / 10.0));
+    ui->mppt2VLabel->setText(QString("%1").arg(volt2 / 10.0));
+    ui->mppt3VLabel->setText(QString("%1").arg(volt3 / 10.0));
+    ui->mppt1ALabel->setText(QString("N/A"));
+    ui->mppt2ALabel->setText(QString("N/A"));
+    ui->mppt3ALabel->setText(QString("N/A"));
+    ui->mppt1PowerLabel->setText(QString("N/A"));
+    ui->mppt2PowerLabel->setText(QString("N/A"));
+    ui->mppt3PowerLabel->setText(QString("N/A"));
+    ui->mppt1ModLabel->setText(QString("N/A"));
+    ui->mppt2ModLabel->setText(QString("N/A"));
+    ui->mppt3ModLabel->setText(QString("N/A"));
+    ui->mppt1StatLabel->setText(QString("N/A"));
+    ui->mppt2StatLabel->setText(QString("N/A"));
+    ui->mppt3StatLabel->setText(QString("N/A"));
+    ui->mppt1PwmLabel->setText(QString("N/A"));
+    ui->mppt2PwmLabel->setText(QString("N/A"));
+    ui->mppt3PwmLabel->setText(QString("N/A"));
+
+    m_cellPower = (QString("N/A").toFloat());
+    updateGraphicsImage();
+    m_MPPTUpdateReset->start(MPPTRESETTIMEMS);
 }
 
 void EnergyBudget::updateGraphicsImage(void)
@@ -424,18 +569,21 @@ void EnergyBudget::updateGraphicsImage(void)
 	}
 }
 
-void EnergyBudget::resizeEvent(QResizeEvent *event)
-{
-	QWidget::resizeEvent(event);
-	ui->overviewGraphicsView->fitInView(m_scene->sceneRect(), Qt::AspectRatioMode::KeepAspectRatio);
-}
+//void EnergyBudget::resizeEvent(QResizeEvent *event)
+//{
+//    QWidget::resizeEvent(event);
+//    ui->overviewGraphicsView->fitInView(m_scene->sceneRect(), Qt::AspectRatioMode::KeepAspectRatio);
+//}
 
 void EnergyBudget::setActiveUAS(void)
 {
     //disconnect any previous uas
     disconnect(this, SLOT(updatePower(float, float, float, float)));
+    disconnect(this, SLOT(updatePowerHL(uint8_t)));
     disconnect(this, SLOT(updateMPPT(float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t)));
+    disconnect(this, SLOT(updateMPPTHL(uint8_t, uint8_t, uint8_t)));
     disconnect(this, SLOT(updateBatMon(uint8_t, uint16_t, int16_t, uint8_t, float, uint16_t, uint16_t, uint16_t,uint8_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t)));
+    disconnect(this, SLOT(updateBatMonHL(uint8_t, uint8_t, int8_t, uint8_t)));
     disconnect(this, SLOT(onThrustChanged(Vehicle*,double)));
     disconnect(this, SLOT(onSensPowerBoardChanged(uint8_t)));
 
@@ -443,8 +591,11 @@ void EnergyBudget::setActiveUAS(void)
     Vehicle* tempUAS = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
 
     connect(tempUAS, SIGNAL(SensPowerChanged(float, float, float, float)), this, SLOT(updatePower(float, float, float, float)));
+    connect(tempUAS, SIGNAL(SensPowerChangedHL(uint8_t)), this, SLOT(updatePowerHL(uint8_t)));
     connect(tempUAS, SIGNAL(MPPTDataChanged(float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t)), this, SLOT(updateMPPT(float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t, float, float, uint16_t, uint8_t)));
+    connect(tempUAS, SIGNAL(MPPTDataChangedHL(uint8_t, uint8_t, uint8_t)), this, SLOT(updateMPPTHL(uint8_t, uint8_t, uint8_t)));
     connect(tempUAS, SIGNAL(BatMonDataChanged(uint8_t, uint16_t, int16_t, uint8_t, float, uint16_t, uint32_t, uint32_t, uint8_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t)), this, SLOT(updateBatMon(uint8_t, uint16_t, int16_t, uint8_t, float, uint16_t, uint32_t, uint32_t, uint8_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t, uint16_t)));
+    connect(tempUAS, SIGNAL(BatMonDataChangedHL(uint8_t, uint8_t, int8_t, uint8_t)), this, SLOT(updateBatMonHL(uint8_t, uint8_t, int8_t, uint8_t)));
 
     connect(tempUAS, SIGNAL(thrustChanged(Vehicle*, double)), this, SLOT(onThrustChanged(Vehicle*, double)));
     connect(tempUAS, SIGNAL(SensPowerBoardChanged(uint8_t)), this, SLOT(onSensPowerBoardChanged(uint8_t)));

--- a/src/ui/EnergyBudget.h
+++ b/src/ui/EnergyBudget.h
@@ -84,7 +84,7 @@ protected slots:
     void updateBatMon(uint8_t compid, uint16_t volt, int16_t current, uint8_t soc, float temp, uint16_t batStatus, uint32_t batSafety, uint32_t batOperation, uint8_t batmonStatusByte, uint16_t cellvolt1, uint16_t cellvolt2, uint16_t cellvolt3, uint16_t cellvolt4, uint16_t cellvolt5, uint16_t cellvolt6);
     void updateBatMonHL(uint8_t compid, uint8_t volt, int8_t p_avg, uint8_t batmonStatusByte);
     void onSensPowerBoardChanged(uint8_t status);
-    void setActiveUAS(void);
+    void setActiveUAS(Vehicle* vehicle);
 	void styleChanged(bool);
     void MPPTTimerTimeout(void);
     void onThrustChanged(Vehicle* vehicle, double);

--- a/src/ui/EnergyBudget.h
+++ b/src/ui/EnergyBudget.h
@@ -69,7 +69,7 @@ protected:
 
 	void buildGraphicsImage();
     qreal adjustImageScale(const QRectF&, QRectF&);
-	virtual void resizeEvent(QResizeEvent * event);
+    //virtual void resizeEvent(QResizeEvent * event);
     void updateGraphicsImage(void);
 	QString convertHostfet(uint16_t);
 	QString convertBatteryStatus(uint16_t);
@@ -78,8 +78,11 @@ protected:
 
 protected slots:
 	void updatePower(float volt, float currpb, float curr_1, float curr_2);
+    void updatePowerHL(uint8_t p_out);
 	void updateMPPT(float volt1, float amp1, uint16_t pwm1, uint8_t status1, float volt2, float amp2, uint16_t pwm2, uint8_t status2, float volt3, float amp3, uint16_t pwm3, uint8_t status3);
+    void updateMPPTHL(uint8_t volt1, uint8_t volt2, uint8_t volt3);
     void updateBatMon(uint8_t compid, uint16_t volt, int16_t current, uint8_t soc, float temp, uint16_t batStatus, uint32_t batSafety, uint32_t batOperation, uint8_t batmonStatusByte, uint16_t cellvolt1, uint16_t cellvolt2, uint16_t cellvolt3, uint16_t cellvolt4, uint16_t cellvolt5, uint16_t cellvolt6);
+    void updateBatMonHL(uint8_t compid, uint8_t volt, int8_t p_avg, uint8_t batmonStatusByte);
     void onSensPowerBoardChanged(uint8_t status);
     void setActiveUAS(void);
 	void styleChanged(bool);

--- a/src/ui/EnergyBudget.ui
+++ b/src/ui/EnergyBudget.ui
@@ -37,6 +37,12 @@
      <height>200</height>
     </size>
    </property>
+   <property name="baseSize">
+    <size>
+     <width>250</width>
+     <height>200</height>
+    </size>
+   </property>
    <property name="verticalScrollBarPolicy">
     <enum>Qt::ScrollBarAlwaysOff</enum>
    </property>

--- a/src/ui/EnergyBudget.ui
+++ b/src/ui/EnergyBudget.ui
@@ -625,7 +625,7 @@
       <rect>
        <x>9</x>
        <y>9</y>
-       <width>57</width>
+       <width>71</width>
        <height>17</height>
       </rect>
      </property>
@@ -636,10 +636,10 @@
     <widget class="QLabel" name="bat1VLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>9</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -652,10 +652,10 @@
     <widget class="QLabel" name="bat2VLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>9</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -668,10 +668,10 @@
     <widget class="QLabel" name="bat3VLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>9</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -686,7 +686,7 @@
       <rect>
        <x>9</x>
        <y>32</y>
-       <width>56</width>
+       <width>71</width>
        <height>17</height>
       </rect>
      </property>
@@ -697,10 +697,10 @@
     <widget class="QLabel" name="bat1ALabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>32</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -713,10 +713,10 @@
     <widget class="QLabel" name="bat2ALabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>32</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -729,10 +729,10 @@
     <widget class="QLabel" name="bat3ALabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>32</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -747,7 +747,7 @@
       <rect>
        <x>9</x>
        <y>55</y>
-       <width>47</width>
+       <width>61</width>
        <height>17</height>
       </rect>
      </property>
@@ -758,10 +758,10 @@
     <widget class="QLabel" name="bat1PowerLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>55</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -774,10 +774,10 @@
     <widget class="QLabel" name="bat2PowerLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>55</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -790,10 +790,10 @@
     <widget class="QLabel" name="bat3PowerLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>55</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -808,7 +808,7 @@
       <rect>
        <x>9</x>
        <y>78</y>
-       <width>42</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -819,10 +819,10 @@
     <widget class="QLabel" name="bat1TempLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>78</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -835,10 +835,10 @@
     <widget class="QLabel" name="bat2TempLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>78</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -851,10 +851,10 @@
     <widget class="QLabel" name="bat3TempLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>78</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -880,10 +880,10 @@
     <widget class="QLabel" name="bat1StatLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>101</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -896,10 +896,10 @@
     <widget class="QLabel" name="bat2StatLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>101</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -912,10 +912,10 @@
     <widget class="QLabel" name="bat3StatLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>101</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -941,10 +941,10 @@
     <widget class="QLabel" name="bat1SafetyLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>124</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -957,10 +957,10 @@
     <widget class="QLabel" name="bat2SafetyLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>124</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -973,10 +973,10 @@
     <widget class="QLabel" name="bat3SafetyLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>124</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -991,7 +991,7 @@
       <rect>
        <x>9</x>
        <y>170</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1002,10 +1002,10 @@
     <widget class="QLabel" name="bat1Cell1Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>170</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1018,10 +1018,10 @@
     <widget class="QLabel" name="bat2Cell1Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>170</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1034,10 +1034,10 @@
     <widget class="QLabel" name="bat3Cell1Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>170</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1052,7 +1052,7 @@
       <rect>
        <x>9</x>
        <y>194</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1063,10 +1063,10 @@
     <widget class="QLabel" name="bat1Cell2Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>194</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1079,10 +1079,10 @@
     <widget class="QLabel" name="bat2Cell2Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>194</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1095,10 +1095,10 @@
     <widget class="QLabel" name="bat3Cell2Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>194</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1113,7 +1113,7 @@
       <rect>
        <x>9</x>
        <y>217</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1124,10 +1124,10 @@
     <widget class="QLabel" name="bat1Cell3Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>217</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1140,10 +1140,10 @@
     <widget class="QLabel" name="bat2Cell3Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>217</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1156,10 +1156,10 @@
     <widget class="QLabel" name="bat3Cell3Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>217</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1174,7 +1174,7 @@
       <rect>
        <x>9</x>
        <y>240</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1185,10 +1185,10 @@
     <widget class="QLabel" name="bat1Cell4Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>240</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1201,10 +1201,10 @@
     <widget class="QLabel" name="bat2Cell4Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>240</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1217,10 +1217,10 @@
     <widget class="QLabel" name="bat3Cell4Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>240</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1235,7 +1235,7 @@
       <rect>
        <x>9</x>
        <y>263</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1246,10 +1246,10 @@
     <widget class="QLabel" name="bat1Cell5Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>263</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1262,10 +1262,10 @@
     <widget class="QLabel" name="bat2Cell5Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>263</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1278,10 +1278,10 @@
     <widget class="QLabel" name="bat3Cell5Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>263</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1296,7 +1296,7 @@
       <rect>
        <x>9</x>
        <y>286</y>
-       <width>38</width>
+       <width>51</width>
        <height>17</height>
       </rect>
      </property>
@@ -1307,10 +1307,10 @@
     <widget class="QLabel" name="bat1Cell6Label">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>286</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1323,10 +1323,10 @@
     <widget class="QLabel" name="bat2Cell6Label">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>286</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -1339,10 +1339,10 @@
     <widget class="QLabel" name="bat3Cell6Label">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>286</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -2011,10 +2011,10 @@
     <widget class="QLabel" name="bat2OperLabel">
      <property name="geometry">
       <rect>
-       <x>260</x>
+       <x>239</x>
        <y>147</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -2040,10 +2040,10 @@
     <widget class="QLabel" name="bat1OperLabel">
      <property name="geometry">
       <rect>
-       <x>151</x>
+       <x>130</x>
        <y>147</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -2056,10 +2056,10 @@
     <widget class="QLabel" name="bat3OperLabel">
      <property name="geometry">
       <rect>
-       <x>367</x>
+       <x>346</x>
        <y>147</y>
-       <width>50</width>
-       <height>17</height>
+       <width>91</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="text">
@@ -2077,7 +2077,7 @@
     <widget class="QPushButton" name="ResetMPPTButton">
      <property name="geometry">
       <rect>
-       <x>160</x>
+       <x>220</x>
        <y>10</y>
        <width>91</width>
        <height>24</height>
@@ -2090,7 +2090,7 @@
     <widget class="QLineEdit" name="ResetMPPTEdit">
      <property name="geometry">
       <rect>
-       <x>130</x>
+       <x>180</x>
        <y>10</y>
        <width>21</width>
        <height>24</height>
@@ -2102,7 +2102,7 @@
       <rect>
        <x>10</x>
        <y>10</y>
-       <width>111</width>
+       <width>141</width>
        <height>24</height>
       </rect>
      </property>

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -393,7 +393,7 @@ QGCView {
                         FactCheckBox {
                             id:         paramAutoSaveCheckBox
                             text:       qsTr("Parameter autosave")
-                            checked:    false
+                            checked:    true
                             fact:       _paramAutoSave
                             visible:    !ScreenTools.isMobile && _paramAutoSave.visible
                             property Fact _paramAutoSave: QGroundControl.settingsManager.appSettings.paramAutoSave


### PR DESCRIPTION
- set values that we dont receive during satcom operation to N/A in the energy widget
- energy widget picture has now the correct size from the beginning
- energy widget should now update even if its open before a vehicle is connected. cannot confirm 100%, but the issue of not updating did not occur since the fix
- changing default values of general and mavlink settings to better fit satcom operation
- added a button in the mission planning view (under the sync menu) to set the vehicles current position as home position