### PR TITLE
Fix build on MS Windows

### DIFF
--- a/QGCExternalLibs.pri
+++ b/QGCExternalLibs.pri
@@ -80,11 +80,14 @@ MacBuild {
 } else:LinuxBuild {
     PKGCONFIG = sdl2
 } else:WindowsBuild {
-    INCLUDEPATH += \
-        $$BASEDIR/libs/lib/sdl2/msvc/include \
+    INCLUDEPATH += $$BASEDIR/libs/lib/sdl2/msvc/include
 
+    contains(QT_ARCH, i386) {
+        LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x86
+    } else {
+        LIBS += -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x64
+    }
     LIBS += \
-        -L$$BASEDIR/libs/lib/sdl2/msvc/lib/x86 \
         -lSDL2main \
         -lSDL2
 }

--- a/src/ui/LED.h
+++ b/src/ui/LED.h
@@ -1,12 +1,11 @@
 #ifndef _LED_H_
 #define _LED_H_
 
-#include <QtDesigner/QtDesigner>
 #include <QWidget>
 
 class QTimer;
 
-class QDESIGNER_WIDGET_EXPORT LED : public QWidget
+class LED : public QWidget
 {
 	Q_OBJECT
 


### PR DESCRIPTION
supersedes #39 

- Cherry-picked fix from upstream to build  QGC on 64bit windows.
- Fixing EnergyWidget (LED.h) to build under windows.


This fix has been successfully compiled under Ubuntu and Windows.