### PR TITLE
Support for Timestamped Commands

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -125,6 +125,13 @@
     "defaultValue":     false
 },
 {
+    "name":             "SendStampedCommands",
+    "shortDescription": "Send the commands with a timestamp",
+    "longDescription":  "If this option is enabled the commands will be sent with a vehicle and utc timestamp.",
+    "type":             "bool",
+    "defaultValue":     false
+},
+{
     "name":             "BaseDeviceFontPointSize",
     "shortDescription": "Application font size",
     "longDescription":  "The point size for the default font used.",

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -36,6 +36,7 @@ const char* AppSettings::showLargeCompassName =                         "ShowLar
 const char* AppSettings::savePathName =                                 "SavePath";
 const char* AppSettings::autoLoadMissionsName =                         "AutoLoadMissions";
 const char* AppSettings::useChecklistName =                             "UseChecklist";
+const char* AppSettings::sendStampedCommandsName =                      "SendStampedCommands";
 const char* AppSettings::mapboxTokenName =                              "MapboxToken";
 const char* AppSettings::esriTokenName =                                "EsriToken";
 const char* AppSettings::defaultFirmwareTypeName =                      "DefaultFirmwareType";
@@ -79,6 +80,7 @@ AppSettings::AppSettings(QObject* parent)
     , _savePathFact                         (NULL)
     , _autoLoadMissionsFact                 (NULL)
     , _useChecklistFact                     (NULL)
+    , _sendStampedCommandsFact              (NULL)
     , _mapboxTokenFact                      (NULL)
     , _esriTokenFact                        (NULL)
     , _defaultFirmwareTypeFact              (NULL)
@@ -231,6 +233,15 @@ Fact* AppSettings::useChecklist(void)
     }
 
     return _useChecklistFact;
+}
+
+Fact* AppSettings::sendStampedCommands(void)
+{
+    if (!_sendStampedCommandsFact) {
+        _sendStampedCommandsFact = _createSettingsFact(sendStampedCommandsName);
+    }
+
+    return _sendStampedCommandsFact;
 }
 
 Fact* AppSettings::appFontPointSize(void)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -38,6 +38,7 @@ public:
     Q_PROPERTY(Fact* savePath                           READ savePath                           CONSTANT)
     Q_PROPERTY(Fact* autoLoadMissions                   READ autoLoadMissions                   CONSTANT)
     Q_PROPERTY(Fact* useChecklist                       READ useChecklist                       CONSTANT)
+    Q_PROPERTY(Fact* sendStampedCommands                READ sendStampedCommands                CONSTANT)
     Q_PROPERTY(Fact* mapboxToken                        READ mapboxToken                        CONSTANT)
     Q_PROPERTY(Fact* esriToken                          READ esriToken                          CONSTANT)
     Q_PROPERTY(Fact* defaultFirmwareType                READ defaultFirmwareType                CONSTANT)
@@ -77,6 +78,7 @@ public:
     Fact* savePath                          (void);
     Fact* autoLoadMissions                  (void);
     Fact* useChecklist                      (void);
+    Fact* sendStampedCommands               (void);
     Fact* mapboxToken                       (void);
     Fact* esriToken                         (void);
     Fact* defaultFirmwareType               (void);
@@ -114,6 +116,7 @@ public:
     static const char* savePathName;
     static const char* autoLoadMissionsName;
     static const char* useChecklistName;
+    static const char* sendStampedCommandsName;
     static const char* mapboxTokenName;
     static const char* esriTokenName;
     static const char* defaultFirmwareTypeName;
@@ -165,6 +168,7 @@ private:
     SettingsFact* _savePathFact;
     SettingsFact* _autoLoadMissionsFact;
     SettingsFact* _useChecklistFact;
+    SettingsFact* _sendStampedCommandsFact;
     SettingsFact* _mapboxTokenFact;
     SettingsFact* _esriTokenFact;
     SettingsFact* _defaultFirmwareTypeFact;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -984,6 +984,9 @@ void Vehicle::_handleHighLatency2(mavlink_message_t& message)
 
     if (highLatency2.timestamp > _vehicleTimestamp) {
         _vehicleTimestamp = highLatency2.timestamp;
+    } else {
+        // do not display an outdated HL2 message
+        return;
     }
 
     QString previousFlightMode;
@@ -2901,6 +2904,7 @@ void Vehicle::setCurrentMissionSequence(int seq)
     if (!_firmwarePlugin->sendHomePositionToVehicle()) {
         seq--;
     }
+
     mavlink_message_t msg;
     mavlink_msg_mission_set_current_pack_chan(_mavlink->getSystemId(),
                                               _mavlink->getComponentId(),

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2905,15 +2905,10 @@ void Vehicle::setCurrentMissionSequence(int seq)
         seq--;
     }
 
-    mavlink_message_t msg;
-    mavlink_msg_mission_set_current_pack_chan(_mavlink->getSystemId(),
-                                              _mavlink->getComponentId(),
-                                              priorityLink()->mavlinkChannel(),
-                                              &msg,
-                                              id(),
-                                              _compID,
-                                              seq);
-    sendMessageOnLink(priorityLink(), msg);
+    sendMavCommand(_defaultComponentId,
+                   MAV_CMD_DO_SET_MISSION_CURRENT,
+                   true, // show error if it fails
+                   seq);
 }
 
 void Vehicle::sendMavCommand(int component, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2180,15 +2180,11 @@ void Vehicle::setFlightMode(const QString& flightMode)
         uint8_t newBaseMode = _base_mode & ~MAV_MODE_FLAG_DECODE_POSITION_CUSTOM_MODE;
         newBaseMode |= base_mode;
 
-        mavlink_message_t msg;
-        mavlink_msg_set_mode_pack_chan(_mavlink->getSystemId(),
-                                       _mavlink->getComponentId(),
-                                       priorityLink()->mavlinkChannel(),
-                                       &msg,
-                                       id(),
-                                       newBaseMode,
-                                       custom_mode);
-        sendMessageOnLink(priorityLink(), msg);
+        sendMavCommand(_defaultComponentId,
+                       MAV_CMD_DO_SET_MODE,
+                       true, // show error if fails
+                       newBaseMode,
+                       custom_mode);
     } else {
         qWarning() << "FirmwarePlugin::setFlightMode failed, flightMode:" << flightMode;
     }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1130,6 +1130,7 @@ private:
     void _handleSensMppt(mavlink_message_t& message);
     void _handleSensBatmon(mavlink_message_t& message);
     void _handleSensorpodStatus(mavlink_message_t& message);
+    uint32_t _getMavlinkEpochTimeElapsed(); ///> get the seconds elapsed since the MAVLink epoch (1.1.2009)
 
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
@@ -1202,6 +1203,8 @@ private:
         MAV_FRAME   frame;
         double      rgParam[7];
         bool        showError;
+        uint32_t    mavlink_epoch_time;
+        uint64_t    vehicle_timestamp;
     } MavCommandQueueEntry_t;
 
     QList<MavCommandQueueEntry_t>   _mavCommandQueue;
@@ -1210,6 +1213,8 @@ private:
     static const int                _mavCommandMaxRetryCount = 3;
     static const int                _mavCommandAckTimeoutMSecs = 3000;
     static const int                _mavCommandAckTimeoutMSecsHighLatency = 120000;
+
+    uint64_t _vehicleTimestamp; ///< The time in microseconds since vehicle boot according to mavlink messages
 
     QString             _prearmError;
     QTimer              _prearmErrorTimer;

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -271,6 +271,14 @@ QGCView {
                                 }
 
                                 FactCheckBox {
+                                    text:       qsTr("Send timestamped commands")
+                                    fact:       _sendStampedCommands
+                                    visible:    _sendStampedCommands.visible
+
+                                    property Fact _sendStampedCommands: QGroundControl.settingsManager.appSettings.sendStampedCommands
+                                }
+
+                                FactCheckBox {
                                     text:       qsTr("Virtual Joystick")
                                     visible:    _virtualJoystick.visible
                                     fact:       _virtualJoystick


### PR DESCRIPTION
- Add a checkbox in the general settings to choose if the stamped commands or regular commands should be used.
- Depending on the settings send regular commands or the stamped versions.
    - The vehicle_timestamp is set using the HIGH_LATENCY2, ATTITUDE, ALTITUDE messages
    - The other info is the mavlink epoch time which is the seconds elapsed since 1.1.2009
- Send commands instead of separate messages to change the mission index and flight mode.
- Do not display outdated HIGH_LATENCY2
    - If an ATTITUDE or ALTITUDE with a more recent vehicle timestamp is received the in the HIGH_LATENCY2 message is ignored.

Should be merged together with the [firmware PR #175](https://github.com/ethz-asl/fw_px4/pull/175)